### PR TITLE
Update Labs sidebar to match Blogs

### DIFF
--- a/_layouts/labs.html
+++ b/_layouts/labs.html
@@ -1,66 +1,109 @@
-<!doctype html>
-<html lang="en">
+---
+layout: default
+---
 
-  {% include head.html %}
-
-  <body>
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top" role="navigation">
-      {% include header.html %}
-    </nav>
-
-    <main role="main" style="margin-top: 60px;">
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-sm-12 col-md-4 col-lg-3 offset-lg-1">
-            <div class="accordion" id="accordionTOC">
-              <div class="card card--sidebar">
-                <div class="card-header card-header--sidebar" id="headingTOC">
-                  <h5 class="mb-0">
-                    <button class="btn btn-link kv-btn-link--sidebar" type="button" data-toggle="collapse" data-target="#collapseTOC" aria-expanded="true" aria-controls="collapseTOC" style="width: 100%; text-align: left;">
-                      Labs
-                    </button>
-                  </h5>
-                </div>
-                <div id="collapseTOC" class="collapse show" aria-labelledby="headingTOC" data-parent="#accordionTOC">
-                  <div class="card-body card-body--sidebar">
-                    {% if site.data.labs_toc.toc[0] %}
-                      {% for item in site.data.labs_toc.toc %}
-                        <h3>{{ item.title }}</h3>
-                        {% if item.subfolderitems[0] %}
-                          {% for entry in item.subfolderitems %}
-                            <h3 class="labs-title">
-                              <a href="{{ site.baseurl }}/{{ entry.url }}" {% if page.title == entry.page %} class="labs-title--item active" {% else %} class="labs-title--item" {% endif %}>{{ entry.page }}</a>
-                            </h3>
-                          {% endfor %}
-                        {% endif %}
-                      {% endfor %}
-                    {% endif %}
-                  </div>
-                </div>
-              </div>
-            </div>
+<div class="container-fluid">
+  <div class="row">
+    <h1 class="page-title">
+      {% if page.title == 'Labs' %}
+        {{ page.title }}
+      {% else %}
+        Labs - {{ page.title }}
+      {% endif %}
+    </h1>
+  </div>
+  <div class="row">
+    <div class="col-sm-12 col-md-3">
+      {% if site.data.labs_toc.toc[0] %}
+        {% for item in site.data.labs_toc.toc %}
+          {% if item.subfolderitems[0] %}
+          <ul class="blogs-navigation">
+            <h3>{{ item.title }}</h3>
+            {% for entry in item.subfolderitems %}
+              <!-- <h3 class="labs-title">
+                <a href="{{ site.baseurl }}/{{ entry.url }}" {% if page.title == entry.page %} class="labs-title--item active" {% else %} class="labs-title--item" {% endif %}>{{ entry.page }}</a>
+              </h3> -->
+              <li class="blogs-navigation--item">
+                <a href="{{ site.baseurl }}/{{ entry.url }}" {% if page.title == entry.page %} class="blogs-navigation--item_link active" {% else %} class="blogs-navigation--item_link" {% endif %}>
+                  {{ entry.page }}
+                </a>
+                {% if entry.subsubfolderitems[0] %}
+                    <ul class="blogs-navigation">
+                    {% for subentry in entry.subsubfolderitems %}
+                        <li class="blogs-navigation--item">
+                          <a href="{{ subentry.url }}" {% if page.title == entry.page %} class="blogs-navigation--item_link active" {% else %} class="blogs-navigation--item_link" {% endif %}>
+                            {{ subentry.page }}
+                          </a>
+                        </li>
+                    {% endfor %}
+                    </ul>
+                  {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+      <!-- {% if site.data.blogs_toc.toc[0] %}
+        {% for item in site.data.blogs_toc.toc %}
+          {% if item.subfolderitems[0] %}
+          <ul class="blogs-navigation">
+            <h3>{{ item.title }}</h3>
+            {% for entry in item.subfolderitems %}
+              <li class="blogs-navigation--item">
+                <a href="{{ entry.url }}" {% if page.title == entry.page %} class="blogs-navigation--item_link active" {% else %} class="blogs-navigation--item_link" {% endif %}>
+                  {{ entry.page }}
+                </a>
+                {% if entry.subsubfolderitems[0] %}
+                    <ul class="blogs-navigation">
+                    {% for subentry in entry.subsubfolderitems %}
+                        <li class="blogs-navigation--item">
+                          <a href="{{ subentry.url }}" {% if page.title == entry.page %} class="blogs-navigation--item_link active" {% else %} class="blogs-navigation--item_link" {% endif %}>
+                            {{ subentry.page }}
+                          </a>
+                        </li>
+                    {% endfor %}
+                    </ul>
+                  {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        {% endfor %}
+      {% endif %} -->
+    </div>
+    <!-- <div class="col-sm-12 col-md-4 col-lg-3 offset-lg-1">
+      <div class="accordion" id="accordionTOC">
+        <div class="card card--sidebar">
+          <div class="card-header card-header--sidebar" id="headingTOC">
+            <h5 class="mb-0">
+              <button class="btn btn-link kv-btn-link--sidebar" type="button" data-toggle="collapse" data-target="#collapseTOC" aria-expanded="true" aria-controls="collapseTOC" style="width: 100%; text-align: left;">
+                Labs
+              </button>
+            </h5>
           </div>
-          <div class="col-sm-12 col-md-8 col-lg-8 docs">
-            {{ content }}
+          <div id="collapseTOC" class="collapse show" aria-labelledby="headingTOC" data-parent="#accordionTOC">
+            <div class="card-body card-body--sidebar">
+              {% if site.data.labs_toc.toc[0] %}
+                {% for item in site.data.labs_toc.toc %}
+                  <h3>{{ item.title }}</h3>
+                  {% if item.subfolderitems[0] %}
+                    {% for entry in item.subfolderitems %}
+                      <h3 class="labs-title">
+                        <a href="{{ site.baseurl }}/{{ entry.url }}" {% if page.title == entry.page %} class="labs-title--item active" {% else %} class="labs-title--item" {% endif %}>{{ entry.page }}</a>
+                      </h3>
+                    {% endfor %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>
-    </main>
+    </div> -->
+    <div class="col-sm-12 col-md-9 docs">
+      {{ content }}
+    </div>
+  </div>
+</div>
 
-    <footer class="footer" role="footer">
-      {% include footer.html %}
-    </footer>
-
-    <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js" integrity="sha384-3LK/3kTpDE/Pkp8gTNp2gR/2gOiwQ6QaO7Td0zV76UFJVhqLl4Vl3KL1We6q6wR9" crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm" crossorigin="anonymous"></script>
-    <script id="dsq-count-scr" src="//kubevirt-io.disqus.com/count.js" async></script>
-    <script src="{{ site.baseurl }}/js/kubevirt-io.js"></script>
-    <script type="text/javascript">
-        if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {
-            _satellite.pageBottom();
-        }
-    </script>
-  </body>
-</html>

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -2,6 +2,7 @@
 layout: labs
 title: Use KubeVirt
 permalink: /labs/kubernetes/lab1
+navbar_active: Labs
 lab: kubernetes
 order: 1
 tags:

--- a/labs/kubernetes/lab2.md
+++ b/labs/kubernetes/lab2.md
@@ -2,6 +2,7 @@
 layout: labs
 title: Experiment with CDI
 permalink: /labs/kubernetes/lab2
+navbar_active: Labs
 lab: kubernetes
 order: 1
 tags: [laboratory, importer, vm import, containerized data importer, CDI, lab]

--- a/labs/kubernetes/lab3.md
+++ b/labs/kubernetes/lab3.md
@@ -1,7 +1,8 @@
 ---
 layout: labs
-title: KubeVirt upgrades
+title: KubeVirt Upgrades
 permalink: /labs/kubernetes/lab3
+navbar_active: Labs
 lab: kubernetes
 order: 1
 tags: [laboratory, kubevirt upgrades, upgrade, lifecycle, lab]

--- a/pages/cloud.md
+++ b/pages/cloud.md
@@ -1,7 +1,8 @@
 ---
 layout: labs
-title: Easy installation on Cloud Providers
+title: Cloud providers
 permalink: pages/cloud
+navbar_active: Labs
 lab: kubernetes
 tags: [GCP, AWS, AliCloud, azure, Amazon, Google, quickstart, tutorial]
 order: 1

--- a/pages/labs.md
+++ b/pages/labs.md
@@ -1,8 +1,9 @@
 ---
 layout: labs
-title: Introduction
+title: Labs
 permalink: /labs/
 order: 10
+navbar_active: Labs
 ---
 
 Check out the Available labs on the side menu

--- a/pages/quickstart_kind.md
+++ b/pages/quickstart_kind.md
@@ -1,7 +1,8 @@
 ---
 layout: labs
-title: KubeVirt Quickstart with Kind
+title: Kind
 permalink: /quickstart_kind/
+navbar_active: Labs
 order: 2
 lab: kubernetes
 tags: [kind, quickstart, tutorial]

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -1,7 +1,8 @@
 ---
 layout: labs
-title: KubeVirt Quickstart with Minikube
+title: Minikube
 permalink: /quickstart_minikube/
+navbar_active: Labs
 redirect_from: "/get_kubevirt/"
 order: 2
 lab: kubernetes


### PR DESCRIPTION
**What this PR does / why we need it:**

Update the Labs sidebar to match the Blogs sidebar
Fix active_nav frontmatter to highlight Labs on correct pages
Fix page titles to match sidebar names for setting the page as active

**Does this PR fix any issue?**

> Fixes #591

**Special notes for your reviewer:**
Requires PR https://github.com/mazzystr/kubevirt.github.io/pull/4 be merged in order to use corrected layout.

Signed-off-by: Adam <mindreeper2420@gmail.com>